### PR TITLE
Updated action to run on Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Addresses Issue #2 

Updated YAML to run against Node 20 to address GitHub deprecating Node 16 actions.